### PR TITLE
Import cl-lib for cl-case

### DIFF
--- a/orgbox.el
+++ b/orgbox.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/yasuhito/orgbox
 ;; Keywords: org
 ;; Version: 0.1.5
-;; Package-Requires: ((org "8.0"))
+;; Package-Requires: ((org "8.0") (cl-lib "0.5"))
 
 ;; This file is not part of Org.
 ;; This file is not part of GNU Emacs.
@@ -43,6 +43,7 @@
 ;;
 ;;; Code:
 
+(require 'cl-lib)
 (require 'org-agenda)
 
 (defun orgbox-later-today ()


### PR DESCRIPTION
I got following byte compile warnings on Emacs development version.

```
Entering directory `/home/syohei/tmp/gomi/orgbox/'

In orgbox:
orgbox.el:100:4:Warning: `108' is a malformed function
orgbox.el:100:4:Warning: `101' is a malformed function
orgbox.el:100:4:Warning: `116' is a malformed function
orgbox.el:100:4:Warning: `119' is a malformed function
orgbox.el:100:4:Warning: `110' is a malformed function
orgbox.el:100:4:Warning: `105' is a malformed function
orgbox.el:100:4:Warning: `115' is a malformed function
orgbox.el:100:4:Warning: `112' is a malformed function
orgbox.el:100:4:Warning: `113' is a malformed function

In end of data:
orgbox.el:127:1:Warning: the function `cl-case' might not be defined at
    runtime.
orgbox.el:127:1:Warning: the function `otherwise' is not known to be defined.

```
