### PR TITLE
Fix markdown in README for image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Usage
 Move your cursor to a task you want to schedule and type <kbd>C-c C-s</kbd>.
 
 [![Screenshot](https://raw.github.com/yasuhito/orgbox/develop/screenshot.png)][screenshot]
+
 [screenshot]: https://raw.github.com/yasuhito/orgbox/develop/screenshot.png
 
 


### PR DESCRIPTION
Currently, the `README.md` file displayed on the repo homepage renders kind of ugly around the screenshot. It looks like there needs to be whitespace between the link and the URL reference; after fixing this, the image and link now render correctly.